### PR TITLE
Handle additional linker arguments correctly

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ from numpy.distutils.core import setup, Extension
 import sys
 import os
 import os.path as path
+import shlex
 
 CLASSIFIERS = """\
 Development Status :: 5 - Production/Stable
@@ -61,7 +62,9 @@ include_dirs = _find_args('-i', 'INCLUDE_DIRS')
 library_dirs = _find_args('-l', 'LIBRARY_DIRS')
 szip_installed = 'SZIP' in os.environ
 compress = 'NO_COMPRESS' not in os.environ
-extra_link_args = os.environ.get('LINK_ARGS', '')
+extra_link_args = None
+if "LINK_ARGS" in os.environ:
+    extra_link_args = shlex.split(os.environ["LINK_ARGS"])
 
 
 msg = 'Cannot proceed without the HDF4 library.  Please ' \
@@ -148,7 +151,7 @@ _hdfext = Extension('pyhdf._hdfext',
                     include_dirs = include_dirs,
                     extra_compile_args = extra_compile_args,
                     library_dirs = library_dirs,
-                    extra_link_args=[extra_link_args],
+                    extra_link_args=extra_link_args,
                     libraries = libraries,
                     )
 


### PR DESCRIPTION
The environment variable `LINK_ARGS` allows the user to specify additional linker flags when building the native code. If this environment variable is not set, an empty string is passed on as default value. When calling the linker via the `subprocess` module, this empty string is interpreted as a file name, which causes the following output.

```
gcc -pthread -shared build/temp.linux-x86_64-3.6/pyhdf/hdfext_wrap.o -L/usr/local/lib -lmfhdf -ldf -ljpeg -lz -lpython3.6m -o build/lib.linux-x86_64-3.6/pyhdf/_hdfext.cpython-36m-x86_64-linux-gnu.so
gcc: error: : No such file or directory
error: Command "gcc -pthread -shared build/temp.linux-x86_64-3.6/pyhdf/hdfext_wrap.o -L/usr/local/lib -lmfhdf -ldf -ljpeg -lz -lpython3.6m -o build/lib.linux-x86_64-3.6/pyhdf/_hdfext.cpython-36m-x86_64-linux-gnu.so " failed with exit status 1
```

Instead of an empty string, `None` should be used as default value. If `LINK_ARGS` is actually set, its value needs to be splitted to allow multiple arguments.